### PR TITLE
fixup: use gitea instead of vaultwarden

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           nix build \
             .#nixosConfigurations.base.config.system.build.toplevel \
             .#nixosConfigurations.ethercalc.config.system.build.toplevel \
-            .#nixosConfigurations.vaultwarden.config.system.build.toplevel
+            .#nixosConfigurations.gitea.config.system.build.toplevel
 
       # Publish the flake to FlakeHub
       - uses: DeterminateSystems/flakehub-push@main

--- a/flake.nix
+++ b/flake.nix
@@ -32,12 +32,12 @@
         };
       };
 
-      vaultwardenModule = {
-        services.vaultwarden = {
+      giteaModule = {
+        services.gitea = {
           enable = true;
-          config = {
-            ROCKET_ADDRESS = "0.0.0.0";
-            ROCKET_PORT = 8080;
+          settings.server = {
+            HTTP_ADDR = "0.0.0.0";
+            HTTP_PORT = 8080;
           };
         };
 
@@ -71,7 +71,10 @@
               }
             )
             {
-              networking.firewall.allowedTCPPorts = [ 80 8080 ];
+              networking.firewall.allowedTCPPorts = [
+                80
+                8080
+              ];
             }
           ]
           ++ modules;
@@ -80,7 +83,7 @@
     {
       nixosConfigurations.base = nixos [ ];
       nixosConfigurations.ethercalc = nixos [ ethercalcModule ];
-      nixosConfigurations.vaultwarden = nixos [ vaultwardenModule ];
+      nixosConfigurations.gitea = nixos [ giteaModule ];
 
       devShells = forAllSystems (
         { system, pkgs, ... }:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated NixOS deployment configuration to replace Vaultwarden with Gitea as the primary service
  * Updated CI/CD pipeline to build the new service configuration
  * Modified firewall rules and adjusted service settings to support the updated infrastructure
  * Updated the top-level NixOS configuration entry to reflect the new deployment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->